### PR TITLE
Revamp documentation and add in-repo wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,163 +1,124 @@
 # 🤖 SIR – Simple In-game Receptionist
 
-Welcome to **SIR**, the versatile and powerful Minecraft plugin that transforms server management and player interaction! With an extensive modular architecture and feature-rich tools, SIR is built to streamline your server’s chat, announcements, and overall communication systems.
+A modular Minecraft assistant that centralizes chat management, announcements, onboarding, and cross-platform communication. SIR ships with a rich configuration toolkit so you can tailor every interaction players see without touching Java code.
 
 ---
 
-## 🌟 Overview
-
-**SIR** is designed with simplicity and efficiency in mind. Whether you need advanced chat management, customizable join/quit messages, automated announcements, or deep integration with other plugins, SIR has you covered.
-
-- **Modular Design:** Activate only the modules you need.
-- **User-Friendly:** Easy configuration and intuitive command system.
-- **Highly Customizable:** Supports extensive formatting, colors, and emojis to enhance the player experience.
-- **Optimized Performance:** Engineered to handle busy servers with minimal resource consumption.
-
----
-
-## 🔧 Key Features
-
-- **Chat Management System** 🗣️  
-  Control chat channels, implement anti-spam cooldowns, and format messages using gradients, colors, and emojis.
-
-- **Custom Join/Quit Messages** 👋  
-  Automatically display personalized messages for players when they join or leave the server.
-
-- **Automated Announcements** 📢  
-  Schedule announcements with custom formats, sound effects, and commands, all adjustable with tick-based intervals.
-
-- **Server MOTD System** 📝  
-  Manage server list messages (MOTDs) with dynamic player count and server icons for that extra professional touch.
-
-- **Advanced Moderation Tools** 🛡️  
-  Filter swearing, manage excessive caps, and control link posting to keep your chat clean and fun.
-
-- **Plugin Integrations** 🔌  
-  Seamlessly integrate with popular plugins like DiscordSRV, PlaceholderAPI, Vault, and many more for an enhanced experience.
+## 🌟 Feature Highlights
+- **Modular architecture** – Toggle self-contained modules for chat, join/quit experiences, announcements, MOTDs, advancements, and third-party hooks.
+- **Deep chat customization** – Build channel hierarchies, apply gradient colours, emojis, hover/click actions, tags, and mention effects directly from YAML.
+- **Player journey controls** – Craft first-join flows, spawn teleport rules, welcome/farewell messages, and timed invulnerability windows.
+- **Automated outreach** – Schedule announcements that mix chat, action bar, title, boss bar, sounds, and console commands.
+- **Discord-ready** – Mirror activity with DiscordSRV or EssentialsDiscord using embed templates, per-event routing, and cross-server relays.
+- **Login & vanish awareness** – Coordinate with major authentication and vanish plugins so muted, hidden, or unauthenticated players follow your rules.
+- **Takion-powered runtime** – The Takion framework is bundled, providing the scheduler, text processors, gradients, and boss bars you rely on—no extra download needed.
+- **Live updates & metrics** – Automatic update checks, optional coloured console logging, and bStats analytics keep administrators informed.
 
 ---
 
-## ⚙️ Technical Details
-
-- **API Version:** 1.13+  
-- **Language:** Java  
-- **Required Dependency:** [Takion](https://github.com/CroaBeast/Takion)  
-- **Extensible Framework:** Supports additional integrations through a modular system and includes extensive APIs for developers.
-
----
-
-## 📦 Module System
-
-SIR’s modular design lets you tailor the plugin to your server’s needs. The modules fall under three main categories:
-
-### 🎮 Core Modules
-1. **Advancements** 🏆  
-   Customize achievement notifications with rewards and commands.
-2. **Announcements** 📢  
-   Schedule and format automated messages and broadcasts.
-3. **Join/Quit** 👋  
-   Set up welcoming and farewell messages with special effects.
-4. **MOTD** 📝  
-   Craft attractive server list messages with dynamic player counts.
-
-### 💬 Chat Modules
-5. **Channels** 🔊  
-   Manage global and local chat channels with custom permissions and formatting.
-6. **Cooldowns** ⏳  
-   Implement anti-spam measures and controlled message sending.
-7. **Emojis** 😊  
-   Replace text with colorful, custom emoji shortcuts.
-8. **Mentions** 📧  
-   Enable interactive player mentions with click and hover effects.
-9. **Tags** 🏷️  
-   Create custom chat tags for different player groups.
-10. **Moderation** 🛡️  
-    Enforce chat rules by blocking swearing, excessive caps, and unwanted links.
-
-### 🔗 Integration Modules
-11. **Discord** 🎮  
-    Connect Minecraft chat with Discord channels via DiscordSRV.
-12. **Login** 🔑  
-    Support authentication plugins such as AuthMe and NexAuth.
-13. **Vanish** 👻  
-    Integrate with vanish plugins to manage invisible players in chat.
+## 🧭 Compatibility Matrix
+| Area | Details |
+| --- | --- |
+| **Minecraft server** | Spigot/Paper/Folia API 1.13+ (Folia flag enabled in `plugin.yml`). |
+| **Java runtime** | Compiled for Java 8 targets while building with Maven (Java 21 toolchain supported). |
+| **Permissions** | Vault-driven chat adapter with automatic fallback when Vault is absent. |
+| **Placeholder support** | PlaceholderAPI expansion included; formats across messages, announcements, and Discord bridge respect PAPI placeholders. |
+| **Text effects** | Takion gradient & rainbow tags, hover/click actions, and InventoryFramework-powered GUIs for chat colour menus. |
+| **Analytics** | bStats (ID 25264) with drill-down charts for detected integrations. |
 
 ---
 
-## 🌈 Dynamic Text & Formatting
-
-SIR not only supports basic text messaging but lets you get creative:
-
-- **Color Gradients & Rainbow Text:**  
-  Use simple tags to create eye-catching gradients and rainbow effects.
-- **Unicode and Small Caps:**  
-  Easily transform text to small caps or include special Unicode characters.
-- **Interactive Chat Components:**  
-  Design messages that respond to hover and click actions, triggering commands or displaying tooltips.
-
-Example:
-```yaml
-message: "<g:#FF0000:#0000FF>Amazing Text</g> <hover:\"Click for help\"|run:\"/help\">Need Help?</text>"
-```
+## 🧩 Built-in & Optional Integrations
+| Category | Supported Plugins / Libraries | Notes |
+| --- | --- | --- |
+| **Bundled libraries** | Takion 1.3, GlobalScheduler, LangUtils | Shaded inside SIR—no external jars needed. |
+| **Metrics** | bStats | Relocated package (`me.croabeast.metrics`) to avoid conflicts. |
+| **Chat & permissions** | Vault, InteractiveChat | Automatically detected; permissions exposed through `commands.yml` and channel configs. |
+| **Placeholder system** | PlaceholderAPI | Optional but fully supported; registers a dedicated expansion. |
+| **Discord bridge** | DiscordSRV, EssentialsDiscord | Route join/quit/advancement/chat events with per-channel embed templates. |
+| **Authentication** | AuthMe, UserLogin, NexAuth, nLogin, OpeNLogin | Shared spawn handling via `modules/hook/login.yml`. |
+| **Vanish handling** | CMI, EssentialsX, SuperVanish, PremiumVanish | Optional vanish chat key rules to block message leaks. |
+| **Moderation synergy** | AdvancedBan and other punishment suites | Use cooldowns, mute commands, and violation actions to complement third-party moderation. |
 
 ---
 
-## 📝 Commands & GUI Integration
+## 🗂️ Modular Platform Overview
+| Module | Purpose | Key Configuration Files |
+| --- | --- | --- |
+| **Join/Quit** | Welcomes players, controls vanilla join/quit spam, and manages spawn & invulnerability. | `modules/join_quit/config.yml`, `modules/join_quit/messages.yml` |
+| **Announcements** | Time-based broadcasts mixing chat, titles, action bars, sounds, and commands. | `modules/announcements/config.yml`, `modules/announcements/announces.yml` |
+| **MOTD** | Rotates server list MOTDs and icons with custom counters. | `modules/motd/config.yml`, `modules/motd/motds.yml` |
+| **Advancements** | Broadcasts achievements with rewards and per-world/mode filters. | `modules/advancements/config.yml`, `modules/advancements/messages.yml` |
+| **Chat – Channels** | Hierarchical global/local channels with inheritance and colour governance. | `modules/chat/channels.yml` (see wiki guide) |
+| **Chat – Cooldowns** | Anti-spam timers and scripted punishments. | `modules/chat/cooldowns.yml` |
+| **Chat – Emojis & Tags** | Replace shortcuts with formatted text and manage permission-based tags. | `modules/chat/emojis.yml`, `modules/chat/tags.yml` |
+| **Chat – Mentions** | Highlight recipients with sounds, hover/click actions, and custom outputs. | `modules/chat/mentions.yml` |
+| **Chat – Moderation** | Filter swears, caps, links, and enforce format standards. | `modules/chat/moderation.yml` |
+| **Hooks – Discord** | DiscordSRV channel routing and embed templates. | `modules/hook/discord.yml`, `webhooks.yml` |
+| **Hooks – Login/Vanish** | Sync behaviour with authentication and vanish plugins. | `modules/hook/login.yml`, `modules/hook/vanish.yml` |
 
-SIR offers an array of commands grouped under four categories:
-
-### 🛠️ Administrative Commands
-- `/sir` – The primary command for administration and configuration.
-- `/print` – Broadcast raw messages with advanced formatting.
-- `/announcer` – Manage your automated announcements.
-
-### 💬 Chat Management
-- `/chatview` – Toggle chat channel visibility.
-- `/ignore` – Ignore messages from specific players.
-- `/clearchat` – Quickly clear the chat screen.
-
-### 📨 Messaging System
-- `/msg` – Send private messages to fellow players.
-- `/reply` – Quickly reply to recent messages.
-
-### 🔇 Moderation Suite
-- `/mute`, `/tempmute`, `/unmute`, `/checkmute` – Commands to handle player moderation and enforce chat rules.
-
-All command configurations are accessible through `commands.yml` or via an intuitive GUI interface, making it simple to adjust settings on the fly.
+All modules are toggled from `modules/modules.yml`, which also manages update tracking for shipped configs.
 
 ---
 
-## 🔄 Automatic Updates & Configuration
+## 💬 Command Suite
+| Command | Summary | Highlights |
+| --- | --- | --- |
+| `/sir` | Administrative hub | About, reload, module status, help, support links. |
+| `/print` | Raw formatted broadcaster | Targeted chat, titles, action bars, Discord webhooks. |
+| `/announcer` | Manage automated announcements | Preview, start/stop, reboot sequences. |
+| `/chatview` | Channel visibility | Players opt in/out of channel subscriptions. |
+| `/chatcolor` | GUI colour selector | Unlockable colours, gradients, rainbow styles. |
+| `/ignore` | Personal mute list | Persistent ignore data per player. |
+| `/clearchat` | Clear local/global chat | Instant moderation tool. |
+| `/msg`, `/reply` | Private messaging | Sound & action feedback for mentions. |
+| `/mute`, `/tempmute`, `/unmute`, `/checkmute` | Moderation controls | Permanent or timed mutes powered by configurable lang/data files. |
 
-SIR comes with an **automatic update system** to keep your configurations fresh:
-- Enable updater settings in your `config.yml` for notifications on startup.
-- Support for dynamic configuration reloads via `/sir reload` ensures changes take effect immediately without disrupting gameplay.
-
----
-
-## 🔗 Quick Links
-
-- **Documentation:** [SIR Wiki](https://github.com/CroaBeast/SIR/wiki)
-- **Discord Support:** [Join Our Discord](https://discord.gg/s9YFGMrjyF)
-- **Issue Tracker:** [Report Issues](https://github.com/CroaBeast/SIR/issues)
-- **Change Log:** [View Commits](https://github.com/CroaBeast/SIR/commits/main)
-
----
-
-## 🛡️ Why Choose SIR?
-
-- **Clean, Intuitive Design:** Enjoy streamlined chat and moderation, making server management hassle-free.
-- **Flexible Configuration:** Customize every aspect using YAML files or a GUI.
-- **Outstanding Performance:** Optimized for efficiency, even on high-traffic servers.
-- **Robust Plugin Integration:** Connect seamlessly with popular plugins to expand functionalities.
-- **Active Community & Developer Support:** Join an engaged community with continuous updates and improvements.
+Command behaviour, aliases, and language strings live under `resources/commands/` for complete customization.
 
 ---
 
-## 🎯 Final Thoughts
+## 🎨 Formatting & Player Experience Toolkit
+- **Message prefixing:** Define the main plugin prefix, centred text tag, and line separators in `config.yml`.
+- **Gradient & rainbow tags:** Use `<G:#RRGGBB:#RRGGBB>` or `<R:n>` syntax anywhere the plugin parses text.
+- **Interactive components:** Attach hover lists and click actions across messages, announcements, and mentions.
+- **Sound design:** Assign unique join/quit, mention, and announcement sounds using vanilla sound keys.
+- **Spawn logic:** Per-message group spawn teleporters align with login plugins when enabled.
+- **Boss bars & titles:** Tap into Takion’s animated boss bars for announcement or module-specific effects.
 
-With **SIR**, you’re not just installing a plugin—you're upgrading your server’s communication framework. The combination of dynamic message formatting, complete module control, and extensive integration options makes SIR the ultimate solution for server administrators aiming for a next-level Minecraft experience. 
+---
 
-> *Powered by [Takion](https://github.com/CroaBeast/Takion) and [PrismaticAPI](https://github.com/CroaBeast/PrismaticAPI), SIR has been making server management simple and efficient since 2021.* 🚀
+## 🚀 Getting Started
+1. **Drop SIR into `plugins/`** – No external dependencies are required; Takion is already shaded inside the jar.
+2. **Start your server once** – Configuration files populate under `plugins/SIR/resources/`.
+3. **Review `config.yml` and `modules/modules.yml`** – Toggle features and adjust update checks.
+4. **Tailor modules** – Edit the YAML files under each module directory to match your server’s tone and rules.
+5. **Grant permissions** – Use your permission manager (Vault-compatible) to assign command and channel access.
+6. **Reload or restart** – `/sir reload` applies configuration changes without a full reboot.
 
-Feel free to explore the documentation further for in-depth configuration examples, command usage, and module management tips. Happy crafting! 🎉
+Need more detail? The wiki pages below dive into each subsystem with copy-paste-ready examples.
+
+---
+
+## 📚 Documentation & Support
+- **Home:** [`wiki/Home.md`](wiki/Home.md)
+- **Setup guide:** [`wiki/Getting-Started.md`](wiki/Getting-Started.md)
+- **Module reference:** [`wiki/Module-Reference.md`](wiki/Module-Reference.md)
+- **Integrations:** [`wiki/Integrations.md`](wiki/Integrations.md)
+- **Chat channels deep dive:** [`wiki/Chat-Channels.md`](wiki/Chat-Channels.md)
+- **Formatting toolkit:** [`wiki/Formatting-Toolkit.md`](wiki/Formatting-Toolkit.md)
+- **Command reference:** [`wiki/Command-Reference.md`](wiki/Command-Reference.md)
+- **Community Discord:** [discord.gg/s9YFGMrjyF](https://discord.gg/s9YFGMrjyF)
+- **Issue tracker:** [github.com/CroaBeast/SIR/issues](https://github.com/CroaBeast/SIR/issues)
+
+---
+
+## 🔒 Telemetry & Privacy
+SIR reports anonymous usage data to bStats (metrics ID `25264`) to help the developer understand which integrations are active. Disable metrics globally in `plugins/bStats/config.yml` or use your firewall if you prefer to opt out.
+
+---
+
+## 🛠️ Contributing & Feedback
+Found a bug or have a feature request? Open an issue on GitHub or reach out through the Discord community. Contributions are welcome—fork the repository, make your improvements, and submit a pull request.
+
+With SIR, you control every step of the conversation players see. Configure once, delight forever.

--- a/wiki/Chat-Channels.md
+++ b/wiki/Chat-Channels.md
@@ -1,0 +1,100 @@
+# Chat Channels
+
+SIR’s channel system lets you create layered chat experiences without editing code. Everything is managed from `resources/modules/chat/channels.yml`.
+
+## File Structure Overview
+```yaml
+default-channel: {...}
+channels:
+  default: {...}
+  vip: {...}
+  local-staff-channel: {...}
+```
+- **`default-channel`** defines fallback values for every setting.
+- **`channels`** lists each active channel. Entries inherit unspecified options from `default-channel`.
+- A channel can also declare a **`local`** subsection to create a child channel that shares formatting but limits range.
+
+## Default Channel Blueprint
+`default-channel` is your safety net. Use it to decide:
+- Whether channels are enabled by default (`enabled`).
+- Base colour permissions (`color-options.normal`, `special`, `rgb`).
+- Default radius (`0` = global, anything above `0` limits chat to that many blocks).
+- Cooldown behaviour and warning message.
+- Fallback message format.
+
+Any channel that omits a property automatically pulls the value from this section.
+
+## Creating a Global Channel
+1. Add a new entry under `channels:` (e.g., `staff:`).
+2. Configure optional fields:
+   - `permission`: Who can join the channel.
+   - `priority`: Higher numbers take precedence when multiple channels compete.
+   - `group`: Require a specific permission-group name.
+   - `prefix` / `suffix`: Visual markers that wrap the player name.
+   - `color`: Default colour applied to `{message}`.
+   - `color-options`: Override which colour codes are allowed.
+   - `hover`: A list of lines that appears when players hover the chat line.
+   - `click-action`: Create suggest/run/URL actions (`SUGGEST:/msg {player}` etc.).
+   - `format`: Final render for the message. Available placeholders include `{player}`, `{message}`, `{prefix}`, `{suffix}`, `{color}`.
+3. Set `global: true` (or omit it, because the default radius of `0` already makes the channel global).
+4. Save the file and reload with `/sir reload`.
+
+## Adding Local Channels
+You can either create a standalone local channel (`global: false`) or a local subchannel inside a global entry.
+
+### Standalone Local Channel
+```yaml
+local-market:
+  global: false
+  permission: chat.market
+  radius: 100
+  access:
+    prefix: "!"
+    commands:
+      - /market
+  format: '[MARKET] &7{player}&8: {color}{message}'
+```
+- Players type the prefix (e.g., `!Hello`) or use the `/market` command to send to this channel.
+- If `radius` is omitted, the value from `default-channel` is used.
+
+### Local Subchannel (Child)
+```yaml
+vip:
+  permission: chat.vip
+  format: '{prefix} {player}: {color}{message}'
+  local:
+    permission: chat.vip.local
+    radius: 50
+    access:
+      prefix: "@"
+      commands:
+        - /viplocal
+    format: '[VIP-LOCAL] {prefix} {player}: {message}'
+```
+- The local entry inherits all properties from its parent (`vip`) unless you override them.
+- Useful for toggling between server-wide VIP chat and a nearby whisper with the same branding.
+
+## Access Controls & Quality-of-Life
+- **Permissions:** Define `permission` on the channel and on any local variant to control membership separately.
+- **Groups:** Optional string that matches the player’s permission-group (handy when multiple permissions share the same tag).
+- **Priority:** Ensures the highest-priority channel claims the message if multiple channels share the same prefix.
+- **Commands & prefixes:** Give players multiple ways to access local channels. Commands appear in tab completion when registered.
+- **World filters:** Add a `worlds:` list to restrict where the channel is available.
+
+## Colour Governance
+- `color-options.normal` toggles standard `&0`-`&f` colours.
+- `color-options.special` toggles `&l`, `&o`, `&n`, `&m`, `&k` formatting.
+- `color-options.rgb` enables hex colours such as `{#C0C0C0}`.
+- Combine these with the `color` field to provide a default tone while still letting players customise within limits.
+
+## Cooldowns & Spam Control
+- Use the global `default-channel.cooldown` to apply a base delay between messages.
+- Override per channel if needed by adding a `cooldown:` block to the channel entry.
+- The `{time}` placeholder inside the cooldown message tells players how long they must wait.
+
+## Troubleshooting
+- **Players see the wrong format:** Ensure the target channel has the highest `priority` among the channels they can access.
+- **Local prefixes not working:** Double-check the `access.prefix` value and confirm `global: false` (or the local child) is enabled.
+- **Hex colours ignored:** Make sure `color-options.rgb` is `true` either on the channel or inherited from `default-channel`.
+
+Design channels that match your community’s needs—SIR’s inheritance model keeps configurations tidy and predictable.

--- a/wiki/Command-Reference.md
+++ b/wiki/Command-Reference.md
@@ -1,0 +1,45 @@
+# Command Reference
+
+Every command is configured through `resources/commands/`. Use this page to understand what each command does and which permissions control it.
+
+## Administrative Commands
+| Command | Default Permission | Purpose | Configuration Files |
+| --- | --- | --- | --- |
+| `/sir` | `sir.admin` | Displays plugin info, module status, reload options, help, and support links. | `commands/sir.yml` |
+| `/sir modules` | `sir.admin.modules` | View enabled/disabled modules. | `commands/sir.yml` |
+| `/sir reload` | `sir.admin.reload` | Reload configurations without restarting. | `commands/sir.yml` |
+| `/sir update` | `sir.admin.update` | Check for updates using Takion’s updater. | `commands/sir.yml` |
+
+## Broadcasting & Messaging
+| Command | Default Permission | Highlights | Configuration Files |
+| --- | --- | --- | --- |
+| `/print` (`/rawmsg`, `/rm`) | `sir.print` | Send formatted chat, action bar, title, boss bar, or webhook messages. | `commands/print.yml` |
+| `/print targets` | `sir.print.targets` | Target specific players or groups. | `commands/print.yml` |
+| `/print webhook` | `sir.print.webhook` | Use presets from `webhooks.yml` to post to Discord. | `commands/print.yml`, `webhooks.yml` |
+| `/announcer` | `sir.announcer` | Start/stop/reboot the automated announcer or preview the next message. | `commands/announcer.yml` |
+| `/chatview` | `sir.chatview` | Toggle visibility for individual chat channels. | `commands/chat_view/` |
+| `/chatcolor` (`/color`, `/cc`) | `sir.chatcolor` | Open the InventoryFramework GUI to choose unlocked colours/effects. | `commands/chat_color/` |
+| `/clearchat` (`/cc`) | `sir.clearchat` | Wipe public chat for moderation. | `commands/clear-chat.yml` |
+
+## Private Messaging Suite
+| Command | Default Permission | Highlights | Configuration Files |
+| --- | --- | --- | --- |
+| `/msg` (`/m`, `/message`, `/tell`) | `sir.message` | Send private messages with hover/click feedback and sounds. | `commands/msg-reply.yml` |
+| `/reply` (`/r`) | `sir.reply` | Respond to the last private message sender. | `commands/msg-reply.yml` |
+| `/ignore` (`/ig`) | `sir.ignore` | Manage a personal ignore list persisted in `commands/ignore/data.yml`. | `commands/ignore/` |
+
+## Moderation Commands
+| Command | Default Permission | Highlights | Configuration Files |
+| --- | --- | --- | --- |
+| `/mute` | `sir.mute.perm` | Apply indefinite mutes; ties into moderation module messaging. | `commands/mute/` |
+| `/tempmute` | `sir.mute.temp` | Apply timed mutes with configurable templates. | `commands/mute/` |
+| `/unmute` | `sir.unmute` | Remove active mutes. | `commands/mute/` |
+| `/checkmute` | `sir.checkmute` | Inspect mute status for a player. | `commands/mute/` |
+
+## Command Tips
+- Many commands support aliases defined in their YAML files (e.g., `/color`, `/rm`, `/ig`).
+- Language strings for success/error messages live alongside each command configuration under `lang.yml` files.
+- Use `/sir commands` in-game to review command availability with their current status and permissions.
+- Disable any command by setting `enabled: false` or `override-existing: false` if you prefer another plugin’s implementation.
+
+Grant permissions through your Vault-compatible manager and reload after editing the YAML files to apply changes.

--- a/wiki/Formatting-Toolkit.md
+++ b/wiki/Formatting-Toolkit.md
@@ -1,0 +1,55 @@
+# Formatting Toolkit
+
+SIR gives you fine-grained control over how text appears in chat, announcements, Discord, and private messages. This page summarises the tools available across the configuration files.
+
+## Global Formatting Settings (`config.yml`)
+- **Prefix management:**
+  - `values.lang-prefix-key` triggers the main prefix anywhere it appears (default `<P>`).
+  - `values.lang-prefix` is the formatted prefix injected into messages (default `&e&lSIR &8>&7`).
+- **Centred text:** Prefix messages with `values.center-prefix` (default `<C>`) to centre them in chat.
+- **Line breaks:** Use `values.line-separator` (default `<n>`) to create multi-line outputs, including titles and action bars.
+- **Coloured console:** Toggle `options.colored-console` if your terminal supports ANSI colours.
+- **Message type prefixing:** Enable `options.show-prefix` to see `[CHAT]`, `[ACTION-BAR]`, etc., in the console.
+
+## Gradient & Rainbow Text
+- `<G:#FF0000:#0000FF>` applies a gradient between two hex colours.
+- `<R:1>` cycles through rainbow colours; adjust the number to change the step.
+- These tags work anywhere SIR parses messages: chat, announcements, MOTDs, join messages, and Discord outputs.
+
+## Interactive Components
+Many YAML entries accept hover and click actions:
+- **Hover lists:** Supply an array of lines under `hover:` (e.g., channel definitions, mentions, tags).
+- **Click actions:** Use `SUGGEST:`, `RUN:`, or `URL:` prefixes inside `click-action` or mention `click` fields.
+- **Mentions:** Configure sender/receiver hover and sound feedback separately in `modules/chat/mentions.yml`.
+- **Announcements:** Combine chat lines, action bars (`[ACTION-BAR]`), and titles (`[TITLE] main<n>subtitle`).
+
+## Sounds & Feedback
+- Join, first-join, quit, and announcement entries can define a `sound:` value using vanilla sound keys.
+- Mentions support distinct sounds for the sender and receiver.
+- Discord messages can include embed colours to visually classify events.
+
+## Tags & Emojis
+- **Tags (`modules/chat/tags.yml`):** Create display prefixes with hover descriptions. Attach permissions, priorities, and groups.
+- **Emojis (`modules/chat/emojis.yml`):** Replace keys such as `:heart:` with coloured text or Unicode. Checks include regex matching, word boundaries, case sensitivity, and permission/group requirements.
+
+## Cooldowns & Feedback Messages
+- Cooldowns reference `{time}` to communicate remaining wait time.
+- Moderation modules provide `{player}`, `{type}`, `{message}` placeholders in log and notification formats.
+- Mention messages can include `{sender}` and `{receiver}` for personalised notifications.
+
+## Discord Embeds
+Inside `modules/hook/discord.yml` you can:
+- Set `embed.color` using named colours or hex values.
+- Configure `author`, `thumbnail`, and `title` fields with placeholders like `{player}`, `{UUID}`, `{prefix}`, `{suffix}`.
+- Toggle `timeStamp` to append the current time automatically.
+
+## Boss Bars & Titles
+- Announcements and other features that use Takion can trigger animated boss bars and layered titles. Use `[TITLE]` lines with `<n>` separators and let the module handle delivery.
+
+## Formatting Best Practices
+1. **Validate colour codes:** Hex colours require braces (`{#C0C0C0}`) in chat formats; `&#FFFFFF` also works in announcements.
+2. **Escape quotes where needed:** Use `"` inside strings defined with double quotes.
+3. **Stay consistent:** Keep similar modules (e.g., join messages) aligned in style for a cohesive presentation.
+4. **Test in-game:** Gradients and centred text can look different depending on font width—preview before finalising.
+
+With these tools you can build memorable experiences, from immersive story events to polished server announcements—all without leaving YAML.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,45 @@
+# Getting Started
+
+This guide walks through installing SIR, preparing the configuration files, and activating the modules that suit your server.
+
+## 1. Installation Checklist
+1. **Download the latest SIR jar** from the project releases page.
+2. **Copy the jar into `plugins/`** on your Spigot/Paper/Folia server. No external libraries are required—Takion and metrics tooling are already packaged in the jar.
+3. **Start the server once**. SIR will generate its data folder and populate `resources/` with default YAML files.
+4. **Confirm the folder layout:**
+   - `plugins/SIR/config.yml`
+   - `plugins/SIR/resources/modules/` (per-feature configuration)
+   - `plugins/SIR/resources/commands/` (command behaviour & language)
+   - `plugins/SIR/resources/webhooks.yml` (Discord webhook presets)
+5. **Stop the server** so you can make configuration changes safely.
+
+## 2. First-Run Priorities
+| File | Purpose | Key Actions |
+| --- | --- | --- |
+| `config.yml` | Global preferences | Decide whether to colour console logs, expose message prefixes, or allow Bukkit’s default configuration methods. |
+| `modules/modules.yml` | Module toggles | Enable/disable Join/Quit, Announcements, MOTD, Advancements, Chat submodules, and external hooks. |
+| `modules/chat/channels.yml` | Channel layout | Review the default/global channel, then design any staff, VIP, or local channels. |
+| `modules/join_quit/messages.yml` | Join, first-join, and quit flows | Customize public/private lines, sounds, and spawn/invulnerability behaviour per permission group. |
+| `modules/announcements/announces.yml` | Automated broadcasts | Mix chat, action bar, title, and command actions to match your schedule. |
+
+## 3. Enabling Modules
+- Toggle each feature flag under `modules/modules.yml`. Nested sections (like `chat.channels` or `hook.discord`) let you disable a single submodule without touching the others.
+- Reload in-game with `/sir reload` or restart the server. SIR logs a summary of loaded/enabled/registered modules so you can verify the state quickly.
+
+## 4. Permissions & Groups
+- SIR reads permissions from your Vault-compatible manager. Check `resources/commands/commands.yml` for every permission node the plugin exposes.
+- Channel, emoji, tag, cooldown, and message rules can also enforce permissions defined inside their respective YAML entries.
+- Use the `group` attribute in emojis, tags, and channels if you rely on group tracking from your permissions plugin.
+
+## 5. Update Management
+- Automatic update checks are controlled in `config.yml` (`updater.on-start`, `updater.send-op`).
+- Each module file contains an `update: true` flag—leave this enabled to receive inline changelog hints when defaults change between versions.
+- SIR’s update checker leverages the bundled Takion utilities and only notifies players with `sir.admin.update` unless you disable OP notifications.
+
+## 6. Troubleshooting Tips
+- **Missing permissions?** Use `/sir commands` or consult the command reference to confirm nodes, then verify they are granted through your permission plugin.
+- **Discord messages not sending?** Make sure `modules/hook/discord.yml` contains valid channel IDs and that DiscordSRV or EssentialsDiscord is running.
+- **Login teleport issues?** Set `spawn-before` in `modules/hook/login.yml` according to your authentication plugin’s expectations and define spawn targets inside join message entries.
+- **Muted players bypassing chat?** Confirm the moderation module’s actions and the `/mute` command configuration under `resources/commands/mute/`.
+
+When in doubt, review the [Module Reference](Module-Reference.md) for per-feature explanations or check console logs—SIR’s startup banner lists exactly which modules and hooks are active.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,38 @@
+# SIR Wiki
+
+Welcome to the knowledge base for **SIR – Simple In-game Receptionist**. This wiki covers installation, configuration, modules, integrations, and day-to-day operations so you can unlock the full power of the plugin without diving into Java code.
+
+## Quick Navigation
+- [Getting Started](Getting-Started.md)
+- [Module Reference](Module-Reference.md)
+- [Integrations](Integrations.md)
+- [Chat Channels Deep Dive](Chat-Channels.md)
+- [Formatting Toolkit](Formatting-Toolkit.md)
+- [Command Reference](Command-Reference.md)
+
+## What You Get with SIR
+- **Conversation control:** Curate announcements, chat channels, private messaging, and moderation from modular YAML files.
+- **Player experience tooling:** Tailor first-join flows, MOTDs, spawn handling, and advancement rewards to guide players through your server.
+- **Cross-platform sync:** Bridge chat, join events, and advancements with Discord while respecting login and vanish plugins.
+- **Takion runtime included:** Scheduling, gradients, animated boss bars, and updater utilities arrive bundled inside the plugin jar.
+- **Administrator insights:** Automated update checks, coloured console output, and bStats metrics provide visibility into the server state.
+
+## Server Compatibility Snapshot
+- **Minecraft:** Spigot, Paper, and Folia derivatives targeting API 1.13 or newer (Folia flag is enabled in the plugin manifest).
+- **Java:** Built with Maven for Java 8 bytecode, tested on modern LTS runtimes.
+- **Permissions:** Vault-backed chat adapter with graceful fallback when no provider is installed.
+- **Placeholders:** Dedicated PlaceholderAPI expansion ensures all text channels, announcements, and Discord templates can access server placeholders.
+
+## Documentation Philosophy
+Every page in this wiki focuses on:
+1. **Where to find the relevant configuration file.**
+2. **What the key options do and how they interact with other modules.**
+3. **Practical examples you can paste into your setup.**
+
+You will not need to reference Java classes or recompile the plugin—everything is managed through YAML and in-game commands.
+
+## Community & Support
+- **Discord:** [discord.gg/s9YFGMrjyF](https://discord.gg/s9YFGMrjyF)
+- **Issue Tracker:** [github.com/CroaBeast/SIR/issues](https://github.com/CroaBeast/SIR/issues)
+
+Have a suggestion? Open a ticket or chat with the community—contributions keep the ecosystem thriving.

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -1,0 +1,51 @@
+# Integrations
+
+SIR detects and collaborates with multiple third-party plugins. This page outlines what each integration does and how to configure it.
+
+## Bundled Libraries
+- **Takion 1.3** – Provides the scheduler, animated boss bars, gradient/formatting engine, updater utilities, and shared resource helpers. The library is shaded inside the jar, so no separate dependency is required.
+- **GlobalScheduler** – Powers synchronous and asynchronous task execution across all modules.
+- **LangUtils & CollectionBuilder** – Handle localisation, delayed logging, and structured configuration loading.
+- **bStats** – Anonymous metrics collection (ID `25264`). Disable it globally through `plugins/bStats/config.yml` if desired.
+
+## Permissions & Chat
+- **Vault** – Grants SIR access to group prefixes/suffixes and permission checks. When Vault is absent the plugin falls back to basic permission logic.
+- **InteractiveChat** – Detected for compatibility so both plugins can cooperate on hover/click components.
+
+## Placeholder Support
+- **PlaceholderAPI** – Optional but recommended. SIR registers an expansion so you can use placeholders in:
+  - Chat formats (`channels.yml`)
+  - Announcements and command outputs
+  - Join/Quit messages and mentions
+  - Discord embed templates
+
+## Discord Bridges
+- **DiscordSRV & EssentialsDiscord** – Enable the Discord hook module to stream first-join, join, quit, chat, and advancement events into Discord channels.
+  - Configure routing in `modules/hook/discord.yml` using channel IDs or cross-server mappings (`OTHER_SERVER_ID:CHANNEL_ID`).
+  - Each event supports plain text and embeds with author, thumbnail, title, description, colour, and timestamp fields.
+  - EssentialsDiscord manages its own configuration; SIR only sends formatted payloads.
+
+## Authentication Plugins
+SIR recognises the following login plugins:
+- AuthMe
+- UserLogin
+- NexAuth
+- nLogin
+- OpeNLogin
+
+Use `modules/hook/login.yml` to decide whether players are teleported before or after authentication (`spawn-before`) and define spawn locations within your join message groups. This prevents location leaks and keeps the onboarding flow consistent across plugins.
+
+## Vanish Plugins
+SIR integrates with vanish solutions such as CMI, EssentialsX, SuperVanish, and PremiumVanish. With the vanish module enabled you can:
+- Block vanished players from chatting entirely.
+- Require a special chat prefix/suffix (with optional regex matching) so staff can intentionally talk while hidden.
+- Provide custom feedback messages when a vanished player attempts to speak without the key.
+
+## Moderation Suites
+- **AdvancedBan and similar tools** – While not required, SIR’s moderation module can complement punishment plugins by running commands after violation limits (e.g., `mute {player} Swearing`).
+- The `/mute`, `/tempmute`, `/unmute`, and `/checkmute` commands store their data under `resources/commands/mute/`, allowing you to align SIR’s mute system with your broader moderation stack.
+
+## Discord Webhooks
+Separate from the Discord hook, `resources/webhooks.yml` lets you define webhook endpoints that the `/print` command can target. Use this to broadcast announcements or staff alerts directly to Discord without relying on DiscordSRV.
+
+Keep these integrations enabled only when you use them—SIR checks for each plugin at startup and logs a summary so you know what was detected.

--- a/wiki/Module-Reference.md
+++ b/wiki/Module-Reference.md
@@ -1,0 +1,90 @@
+# Module Reference
+
+SIR divides its functionality into modular building blocks. Toggle them from `resources/modules/modules.yml`, then use the linked configuration files to adjust behaviour.
+
+## Join & Quit
+- **Primary files:** `modules/join_quit/config.yml`, `modules/join_quit/messages.yml`
+- **Highlights:**
+  - Disable vanilla join/quit spam while leaving SIR’s custom messages intact.
+  - Apply cooldowns between join/quit announcements to prevent rapid reconnect spam.
+  - Define first-join, group-based join, and quit messages with separate public/private outputs.
+  - Attach sounds, invulnerability windows, spawn teleports, and priority-based overrides per entry.
+
+## Announcements
+- **Primary files:** `modules/announcements/config.yml`, `modules/announcements/announces.yml`
+- **Highlights:**
+  - Schedule broadcasts in ticks with sequential or random rotation.
+  - Combine chat, action bar, title/subtitle, boss bar, and sound effects in a single announcement entry.
+  - Execute console commands alongside each broadcast to trigger events or rewards.
+
+## MOTD
+- **Primary files:** `modules/motd/config.yml`, `modules/motd/motds.yml`
+- **Highlights:**
+  - Switch between default, maximum, or custom server-list player counts.
+  - Rotate icons (single, random, or ordered lists) from the dedicated icons folder.
+  - Maintain multiple MOTD styles with two-line formatting and rainbow/colour tags.
+
+## Advancements
+- **Primary files:** `modules/advancements/config.yml`, `modules/advancements/messages.yml`
+- **Highlights:**
+  - Filter advancement broadcasts by world, game mode, or specific advancement IDs.
+  - Tailor message formats for task, goal, challenge, and custom advancements.
+  - Reward players with console or player-executed commands triggered by advancement completions.
+
+## Chat System
+This module is composed of several submodules—enable or disable each individually.
+
+### Channels
+- **File:** `modules/chat/channels.yml`
+- Manage global and local channels with inheritance from `default-channel`.
+- Assign permissions, priorities, prefixes/suffixes, click or hover actions, and colour policies per channel.
+- Configure local subchannels with message prefixes or commands for quick access. See the [Chat Channels](Chat-Channels.md) guide for an in-depth walkthrough.
+
+### Cooldowns
+- **File:** `modules/chat/cooldowns.yml`
+- Define per-permission cooldown timers and spam checks.
+- Trigger console commands and custom warning messages when thresholds are exceeded.
+
+### Emojis
+- **File:** `modules/chat/emojis.yml`
+- Replace shortcuts with coloured, formatted text or Unicode characters.
+- Enforce permission, priority, and group rules, plus regex or word-only matching to fine-tune replacements.
+
+### Mentions
+- **File:** `modules/chat/mentions.yml`
+- Allow players to ping each other with sound feedback, hover tooltips, click-to-reply actions, and custom display formats.
+- Configure different mention profiles with unique permissions or prefixes.
+
+### Moderation
+- **File:** `modules/chat/moderation.yml`
+- Block or replace swearing, excessive caps, or unapproved links with tiered violation limits.
+- Notify staff with configurable permission checks and log violations to the console.
+- Optionally enforce automatic message formatting (capitalization, prefixes, suffixes).
+
+### Tags
+- **File:** `modules/chat/tags.yml`
+- Provide customisable chat tags with permission, priority, and group requirements.
+- Supply hover descriptions so players understand how tags are earned.
+
+## Discord Hook
+- **File:** `modules/hook/discord.yml`
+- Route first-join, join, quit, chat, and advancement events to specific DiscordSRV or EssentialsDiscord channels.
+- Mix plain text with embed sections (author, thumbnail, description, timestamp, colours) per event.
+- Support cross-server relays using the `OTHER_SERVER_ID:CHANNEL_ID` syntax.
+
+## Login Hook
+- **File:** `modules/hook/login.yml`
+- Coordinate with authentication plugins (AuthMe, UserLogin, NexAuth, nLogin, OpeNLogin).
+- Teleport players before or after authentication and reuse join message spawn definitions for consistent behaviour.
+
+## Vanish Hook
+- **File:** `modules/hook/vanish.yml`
+- Detect players hidden by vanish plugins (CMI, EssentialsX, SuperVanish, etc.).
+- Optionally require a chat key prefix/suffix (with regex support) to let vanished players talk, or block them entirely with a friendly error message.
+
+## Command Configurations
+- **Directory:** `resources/commands/`
+- Includes per-command toggles, aliases, permission nodes, GUI menus (chat colour selector), language entries, and stored data.
+- Update these files to alter the behaviour of `/sir`, `/print`, `/announcer`, `/chatview`, `/chatcolor`, `/ignore`, `/clearchat`, `/msg`, `/reply`, and the mute suite.
+
+Use the module toggles to keep only what you need—SIR’s architecture ensures unused systems stay dormant and do not impact performance.


### PR DESCRIPTION
## Summary
- overhaul the README to reflect current modules, integrations, commands, and bundled Takion runtime
- add a comprehensive wiki detailing setup, modules, integrations, chat channel configuration, formatting tools, and command usage

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec380c9948328a5f6b8119cba1857)